### PR TITLE
Restored compatibility with python 3.6.8. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,33 +19,15 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7.0"
+python = "^3.6.8"
 systemrdl-compiler = "^1.25.0"
 peakrdl = "^1.1.0"
 py-markdown-table = "^0.3.3"
-
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.21.0"
-
-[tool.poetry.group.lint.dependencies]
-black = "^22.8.0"
-isort = "^5.10.1"
-mypy = "^0.971"
-pydocstyle = "^6.1.1"
-pylint = "<2.15"  # Python 3.7.0 requirement.
-ruff = "^0.1.5"
-
-[tool.poetry.group.test.dependencies]
-pytest = "^7.1.3"
-pytest-cov = "^4.0.0"
-pylint-pytest = "^1.1.2"
-coveralls = "^3.3.1"
-
-[tool.poetry.group.doc.dependencies]
 linuxdoc = "^20211220"
 Sphinx = "^5.2.3"
 sphinx-rtd-theme = "^1.0.0"
 m2r2 = "<0.3.3"
+dataclasses = "0.8"
 
 [tool.poetry.plugins."peakrdl.exporters"]
 "markdown" = "peakrdl_markdown.__peakrdl__:Exporter"


### PR DESCRIPTION
"After all, who needs testing?"

Remove dependencies breaking the compatibility with python 3.6.8.
This removes all the testing features for this repo.
DO NOT USE unless for the specified use.